### PR TITLE
Replace script https to http

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
               <h2>I want to run it now!</h2>
               <br />
               <p>Execute this command <b>inside an Ubuntu 14.04 Virtual Machine</b> with at least 4Gb of memory (8Gb recommended)</p>
-                  <pre>$ wget -qO- https://midonet.org/midonet-quickstart.sh | sudo bash</pre>
+                  <pre>$ wget -qO- http://midonet.org/midonet-quickstart.sh | sudo bash</pre>
                   <p>This command will install a MidoNet 2015.01 with OpenStack Juno. It will give the instructions to log in into Horizon once finished.</p>
               <br />
               <br />

--- a/midonet-quickstart.sh
+++ b/midonet-quickstart.sh
@@ -220,7 +220,9 @@ configure_puppet_manifests() {
 
 	# Most images does not have the fqdn infored via 'facter'. This line
 	# tricks the deployment using fqdn as the same value as hostname
-	\$fqdn = \$::hostname
+    if ! defined (\$::fqdn) {
+	    \$fqdn = \$::hostname
+    }
 	include midonet_openstack::role::allinone
 
 	EOF


### PR DESCRIPTION
Https needs a --no-check-certificate as a parameter. To avoid this
parameter, we rather move to `http`

Ensure there is not already an $::fqdn defined in the host machine.