### PR TITLE
Use `empty` instead of `defined` in fqdn

### DIFF
--- a/midonet-quickstart.sh
+++ b/midonet-quickstart.sh
@@ -220,7 +220,7 @@ configure_puppet_manifests() {
 
 	# Most images does not have the fqdn infored via 'facter'. This line
 	# tricks the deployment using fqdn as the same value as hostname
-    if ! defined (\$::fqdn) {
+    if empty(\$::fqdn) {
 	    \$fqdn = \$::hostname
     }
 	include midonet_openstack::role::allinone


### PR DESCRIPTION
Some images have `fqdn` defined, some of them don't. We have to make
sure the `fqdn` is defined in the all-in-one script. Check if the
variable is empty and, if so, assign it with `hostname` value

cc/ @adjohn 