### PR TITLE
Changing .qbox to box-model

### DIFF
--- a/style.css
+++ b/style.css
@@ -592,6 +592,7 @@ H1.section-heading::after {
 	color:#3a3a3a !important;
 }
 .qbox {
+	box-sizing: border-box;
 	width:960px;
 	text-align:left;
 	margin:20px auto 10px auto;


### PR DESCRIPTION
Pretty sure that was how it was intended, looking at the width and padding. Partly fixes the issue with the positioning of the top-right corner badges.