### PR TITLE
Make sure no .wrapper childs are oversize

### DIFF
--- a/style.css
+++ b/style.css
@@ -17,6 +17,9 @@
 	margin: 0 auto;
 	position: relative;
 }
+.wrapper * {
+    max-width: 100%;
+}
 /*SECTIONS*/
 .users {
 	width: 100%;


### PR DESCRIPTION
Most notably down-scales images that are wider than the .wrapper elements, thus keeping the intended layout. Fixes the remaining positioning issue with the top-right corner badges on small devices.