### PR TITLE
Removing direct links two cherry-picked docs

### DIFF
--- a/_footer.php
+++ b/_footer.php
@@ -14,9 +14,7 @@
        <ul>
          <li><a href="http://midokura.com">Sponsored by Midokura</a></li>
          <li><a href="http://docs.midonet.org">Documentation</a></li>
-         <li><a href="http://docs.midonet.org/docs/latest/rest-api/">&nbsp;- API Specification</a></li>
-         <li><a href="http://docs.midonet.org/docs/latest/quick-start-guide/rhel-7_icehouse/">&nbsp;- QuickStart on RHEL/CentOS</a></li>
-         <li><a href="http://docs.midonet.org/docs/latest/quick-start-guide/ubuntu-1404_icehouse/">&nbsp;- QuickStart on Ubuntu</a></li>
+         <li><a href="http://docs.midonet.org/docs/latest/rest-api/">API Specification</a></li>
        </ul>
        <ul class="social">
          <li class="twitter"><a href="http://twitter.com/midonet">@midonet</a></li>


### PR DESCRIPTION
They just tend to be outdated, and we have to update them manually every time (not only here, but also on docs.midonet.org and wiki.midonet.org) so let's just get rid of them. There's also lots of different guides available at docs.midonet.org and this implies it's only those two plus the API spec.